### PR TITLE
ci(check): only run `on:push` for `main` branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,10 +3,13 @@ name: Check
 on:
   workflow_dispatch:  # can be triggered manually
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - synchronize
+      - reopened
   push:
-    branches-ignore:
-      - update/*
+    branches:
+      - main
     paths-ignore:
       - "LICENSE"
       - "**.md"


### PR DESCRIPTION
Assume other branches are for pull requests.
