### PR TITLE
feat(nixos): disable gcr-ssh-agent because I use gpg-agent

### DIFF
--- a/modules/nixos/gpg.nix
+++ b/modules/nixos/gpg.nix
@@ -1,0 +1,9 @@
+{
+  # Since https://github.com/NixOS/nixpkgs/pull/379731
+  # the new `services.gcr-ssh-agent` option is enabled by default when
+  # `services.gnome.gnome-keyring` is enabled.
+  #
+  # This is incompatible with gpg-agent's ssh support,
+  # which I configure from home-manager.
+  services.gnome.gcr-ssh-agent.enable = false;
+}


### PR DESCRIPTION
The new `services.gnome.gcr-ssh-agent` option, added in https://github.com/NixOS/nixpkgs/pull/379731, is enabled by default when `services.gnome.gnome-keyring` is enabled. This is incompatible with the gpg-agent ssh support that can be enabled through NixOS's `programs.gnupg.agent` or home-manager's `services.gpg-agent` options.

I have been using home-manager's `services.gpg-agent` option.

NixOS has some assertions that check specific combinations of ssh-agents aren't enabled simultaneously, however these are just spot checking _specific_ cases. They also only check other NixOS options, as there's no sensible way for NixOS for check home-manager options in its assertions. Maybe home-manager could check `osConfig` in its assertions though?
