### PR TITLE
feat(games): install MCPE launcher

### DIFF
--- a/modules/nixos/games.nix
+++ b/modules/nixos/games.nix
@@ -37,6 +37,7 @@ in
       prismlauncher
       steam-run
       inputs.umu-launcher.packages.${system}.default
+      mcpelauncher-ui-qt
       nexusmods-app-unfree
       mangohud
       goverlay # mangohud config GUI


### PR DESCRIPTION
For playing Minecraft Bedrock Edition, via the Google Play Store (Android) version.
