### PR TITLE
ci(update): cleanup

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -41,6 +41,14 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ steps.app-token.outputs.token }}
 
+      - name: Extract commit summary
+        id: nix-config
+        run: |
+          {
+            echo -n "commit-lock-file-summary="
+            nix-instantiate --eval --raw flake.nix --attr nixConfig.commit-lock-file-summary
+          } >>"$GITHUB_OUTPUT"
+
       - name: Update flake.lock
         id: update
         uses: DeterminateSystems/update-flake-lock@main
@@ -50,7 +58,8 @@ jobs:
           git-committer-email: ${{ steps.user.outputs.email }}
           git-author-name: ${{ steps.user.outputs.name }}
           git-author-email: ${{ steps.user.outputs.email }}
-          pr-title: 'chore(flake): update inputs'
+          commit-msg: ${{ steps.nix-config.outputs.commit-lock-file-summary }}
+          pr-title: ${{ steps.nix-config.outputs.commit-lock-file-summary }}
           pr-body: |
             Automated update by the [update-flake-lock] GitHub Action.
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -54,12 +54,12 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@main
         with:
           token: ${{ steps.app-token.outputs.token }}
-          git-committer-name: ${{ steps.user.outputs.name }}
-          git-committer-email: ${{ steps.user.outputs.email }}
-          git-author-name: ${{ steps.user.outputs.name }}
-          git-author-email: ${{ steps.user.outputs.email }}
-          commit-msg: ${{ steps.nix-config.outputs.commit-lock-file-summary }}
-          pr-title: ${{ steps.nix-config.outputs.commit-lock-file-summary }}
+          git-committer-name: &name ${{ steps.user.outputs.name }}
+          git-committer-email: &email ${{ steps.user.outputs.email }}
+          git-author-name: *name
+          git-author-email: *email
+          commit-msg: &summary ${{ steps.nix-config.outputs.commit-lock-file-summary }}
+          pr-title: *summary
           pr-body: |
             Automated update by the [update-flake-lock] GitHub Action.
 

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
   };
 
   nixConfig = {
+    commit-lock-file-summary = "chore(flake): update inputs";
     extra-substituters = [
       "https://matt-sturgeon.cachix.org"
       "https://nix-community.cachix.org"


### PR DESCRIPTION
- **chore(flake): specify `commit-lock-file-summary`**
- **ci(update): get commit message from `nixConfig`**
- **ci(update): use yaml anchor/aliases**

Test runs:
- https://github.com/MattSturgeon/nix-config/actions/runs/17344612735
  - Opened https://github.com/MattSturgeon/nix-config/pull/81