### PR TITLE
ci(update): explicitly set `base` branch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -76,6 +76,7 @@ jobs:
 
           pr-labels: dependencies
           pr-assignees: MattSturgeon
+          base: ${{ github.ref_name }}
           branch: update/${{ github.ref_name }}
 
       - name: Summary


### PR DESCRIPTION
This should already be the default, however it doesn't seem to be.

I noticed the PR opened by https://github.com/MattSturgeon/nix-config/actions/runs/17344612735 (#81) is targeting `main`, when the base branch _should_ be `ci/update-cleanup`.

It looks like `inputs.base` has no default and is correctly passed to the peter-evans/create-pull-request step, so maybe it is a bug in the peter-evans/create-pull-request action?

Tested:
- https://github.com/MattSturgeon/nix-config/actions/runs/17344834544
  - Opened PR https://github.com/MattSturgeon/nix-config/pull/83, correctly targeting `ci/update/fix-base-branch`