### PR TITLE
feat(intellij): wrap with libraries

### DIFF
--- a/modules/home-manager/intellij.nix
+++ b/modules/home-manager/intellij.nix
@@ -12,26 +12,66 @@ let
   ];
 
   cfg = config.custom.editors;
+
+  idea = with pkgs.jetbrains; plugins.addPlugins idea-community-bin idea-plugins;
+
+  # NOTE: the jetbrains packages already do similar wrapping internally.
+  # TODO: make it easier to extend `extraLdPath` and other arguments via overrides,
+  # e.g. by using a finalAttrs-style derivation.
+  ideaWrapped =
+    pkgs.runCommand idea.name
+      {
+        env.ide = idea;
+        env.roodDir = idea.meta.mainProgram;
+
+        nativeBuildInputs = with pkgs; [
+          makeWrapper
+        ];
+
+        inherit (idea) meta passthru;
+      }
+      ''
+        cp -r "$ide" "$out"
+        chmod +w -R "$out"
+
+        (
+          shopt -s nullglob
+
+          for exe in "$out/$rootDir"/bin/*
+          do
+            if [ -x "$exe" ] && ( file "$exe" | grep -q 'text' )
+            then
+              substituteInPlace "$exe" --replace-quiet "$ide" "$out"
+            fi
+            wrapProgram "$exe" \
+              --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath cfg.extraIdeaLibs}
+          done
+        )
+      '';
 in
 {
   options.custom.editors = {
     idea = mkEnableOption "Enable Intellij IDEA";
+    extraIdeaLibs = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = [ ];
+      description = "Extra packages to include on idea's `LD_LIBRARY_PATH`.";
+    };
   };
 
-  config = mkIf cfg.idea {
-    home.packages = with pkgs.jetbrains; [
-      (plugins.addPlugins idea-community-bin idea-plugins)
+  config = {
+    home.packages = mkIf cfg.idea [
+      ideaWrapped
     ];
 
-    home.sessionVariables = {
-      # Needed to launch Minecraft in Intellij
-      LD_LIBRARY_PATH = lib.makeLibraryPath (
-        with pkgs;
-        [
-          libglvnd
-          pulseaudio
-        ]
-      );
-    };
+    # Needed to launch Minecraft in Intellij
+    custom.editors.extraIdeaLibs = with pkgs; [
+      flite
+      glfw-wayland-minecraft
+      libGL
+      libpulseaudio
+      libusb1
+      udev
+    ];
   };
 }


### PR DESCRIPTION
Previously I defined `LD_LIBRARY_PATH` globally, however that isn't ideal.

Instead, implement a wrapper for intellij to define `LD_LIBRARY_PATH` just for it.

Another alternative approach would be to do this per-project and set `LD_LIBRARY_PATH` in a devshell. Such a shell could be loaded by the intellij direnv plugin. I'm not doing this because I want GL and GLFW to work on all projects, even if the project _doesn't_ have a nix shell.
