### PR TITLE
Test out firewalld-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,29 @@
         "type": "gitlab"
       }
     },
+    "firewalld-nix": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744515199,
+        "narHash": "sha256-I3Gdp+9IMrtAd7WLRPpVg6C3cvHyDmM2RmKpWKI6/ek=",
+        "owner": "~prince213",
+        "repo": "firewalld-nix",
+        "rev": "1e804086044c71c8bed4b4112a7567a82cc2e8f4",
+        "type": "sourcehut"
+      },
+      "original": {
+        "owner": "~prince213",
+        "repo": "firewalld-nix",
+        "type": "sourcehut"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1747692964,
@@ -284,6 +307,7 @@
       "inputs": {
         "disko": "disko",
         "firefox-addons": "firefox-addons",
+        "firewalld-nix": "firewalld-nix",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "hardware": "hardware",

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    firewalld-nix = {
+      url = "sourcehut:~prince213/firewalld-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
+
     firefox-addons = {
       url = "gitlab:rycee/nur-expressions?dir=pkgs/firefox-addons";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/desktop/configuration.nix
+++ b/hosts/desktop/configuration.nix
@@ -7,7 +7,8 @@
   custom = {
     boot.splash = true;
     desktop.gnome = true;
-    docker.enable = true;
+    # FIXME: Disabled for now due to incompatibility with firewalld
+    # docker.enable = true;
     impermanence.enable = true;
     impermanence.wipeOnBoot = true;
     flatpak.enable = true;

--- a/modules/nixos/firewall.nix
+++ b/modules/nixos/firewall.nix
@@ -1,0 +1,9 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.firewalld-nix.nixosModules.default
+  ];
+
+  # Use firewalld for dynamic firewall zones that integrate well with networkmanager.
+  services.firewalld.enable = true;
+}

--- a/modules/nixos/games.nix
+++ b/modules/nixos/games.nix
@@ -8,15 +8,6 @@
 let
   cfg = config.custom.gaming;
   inherit (pkgs.stdenv.hostPlatform) system;
-
-  minecraftPorts = {
-    bedrock = 19132;
-    java = 25565;
-    lanJava = {
-      from = 40000;
-      to = 65535;
-    };
-  };
 in
 {
   options.custom.gaming.enable = lib.mkEnableOption "gaming";
@@ -42,22 +33,5 @@ in
       mangohud
       goverlay # mangohud config GUI
     ];
-
-    networking.firewall = {
-      allowedTCPPorts = [
-        minecraftPorts.bedrock
-        minecraftPorts.java
-      ];
-      allowedUDPPorts = [
-        minecraftPorts.bedrock
-        minecraftPorts.java
-      ];
-      allowedTCPPortRanges = [
-        minecraftPorts.lanJava
-      ];
-      allowedUDPPortRanges = [
-        minecraftPorts.lanJava
-      ];
-    };
   };
 }


### PR DESCRIPTION
Similar to #87, but instead of testing the nixpkgs PR this tests the out-of-tree [firewalld-nix](https://git.sr.ht/~prince213/firewalld-nix) flake.
