### PR TITLE
fix(firewall): fix open-to-lan iptables rule

### DIFF
--- a/modules/nixos/firewall.nix
+++ b/modules/nixos/firewall.nix
@@ -13,7 +13,27 @@ in
     # For iptables configs
     extraCommands = lib.mkIf (!nftables.enable) ''
       # Accept all LAN traffic
-      iptables --append INPUT --source 192.168.1.0/24 --jump ACCEPT
+      iptables --append nixos-fw \
+        --protocol tcp \
+        --source 192.168.1.0/24 \
+        --jump nixos-fw-accept
+      iptables --append nixos-fw \
+        --protocol udp \
+        --source 192.168.1.0/24 \
+        --jump nixos-fw-accept ||
+        true
+    '';
+    extraStopCommands = lib.mkIf (!nftables.enable) ''
+      # Accept all LAN traffic
+      iptables --delete nixos-fw \
+        --protocol tcp \
+        --source 192.168.1.0/24 \
+        --jump nixos-fw-accept
+      iptables --delete nixos-fw \
+        --protocol udp \
+        --source 192.168.1.0/24 \
+        --jump nixos-fw-accept ||
+        true
     '';
   };
 }


### PR DESCRIPTION
For some reason the open LAN firewall rules (that I tested previously) are no longer working. Let's try targeting the internal nixos stuff instead of the default iptables stuff?

- Instead of appending to 'INPUT', append to the internal 'nixos-fw'
- Instead of jumping to 'ACCEPT', jump to 'nixos-fw-accept'

Inspired by https://discourse.nixos.org/t/open-firewall-ports-only-towards-local-network/13037/2
