### PR TITLE
chore: update MC Quad world to 26.1.2

### DIFF
--- a/hosts/desktop/minecraft.nix
+++ b/hosts/desktop/minecraft.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   self,
   inputs,
   config,
@@ -27,7 +28,11 @@ in
     servers = {
       "quad" = {
         enable = true;
-        package = minecraftServers.fabric-1_21_11;
+        package = minecraftServers.fabric-26_1_2.override (old: {
+          jre_headless = lib.warnIf (
+            lib.versions.major old.jre_headless.version == "25"
+          ) "nix-minecraft is using Java 25, override is now redundant" pkgs.openjdk25_headless;
+        });
         jvmOpts = "-Xmx4G -Xms1G";
         serverProperties = {
           motd = "Matt's Quad world";
@@ -44,12 +49,12 @@ in
         # Modrinth mods defined by their version IDs.
         # Add/update version IDs here, then run: nix run .#update-modrinth-lock
         mods = {
-          fabric-api.modrinth = "gB6TkYEJ";
-          lithium.modrinth = "4DdLmtyz";
-          ferrite-core.modrinth = "eRLwt73x";
-          simple-voice-chat.modrinth = "T42QJY4i";
-          shulker-box-tooltip.modrinth = "8Z4OG11C";
-          apple-skin.modrinth = "pvcLnrm0";
+          fabric-api.modrinth = "BLz7ETCw";
+          lithium.modrinth = "R7MxYvuW";
+          ferrite-core.modrinth = "d5ddUdiB";
+          simple-voice-chat.modrinth = "gVPjsMto";
+          shulker-box-tooltip.modrinth = "Yn66yzx3";
+          apple-skin.modrinth = "HwaLJe3v";
         };
       };
     };

--- a/modrinth.lock
+++ b/modrinth.lock
@@ -1,26 +1,26 @@
 {
-  "4DdLmtyz": {
-    "sha512": "0857d30d063dc704a264b2fe774a7e641926193cfdcde72fe2cd603043d8548045b955e30c05b1b2b96ef7d1c0f85d55269da26f44a0644c984b45623e976794",
-    "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/4DdLmtyz/lithium-fabric-0.21.1%2Bmc1.21.11.jar"
+  "BLz7ETCw": {
+    "sha512": "47ffa18369260c88ea847f6694ccb431a5aa9051c64e8d361186a767bb762dd9fcfbf4742ac65505eb60862900a1a3f1490994e7435376607de811eab8be4461",
+    "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/BLz7ETCw/fabric-api-0.149.1%2B26.1.2.jar"
   },
-  "8Z4OG11C": {
-    "sha512": "55490c21c98a6c5bd704674a7435a7df2853e9e7ab8872b2a62264444110ad11eac23133e0c1e36ff484531bf849d5fa4a71eb0bf32a9b9c4f3afe33779d1c71",
-    "url": "https://cdn.modrinth.com/data/2M01OLQq/versions/8Z4OG11C/shulkerboxtooltip-fabric-5.2.14%2B1.21.11.jar"
+  "HwaLJe3v": {
+    "sha512": "79293a0de5a00f46296c94bb1f1c6b1d13f1b16c7ccbb5afe8c047edb2bc6d1034a43af11674f686ba3704c7f38c0a4ea92090eed652f8a87a6e679014db2197",
+    "url": "https://cdn.modrinth.com/data/EsAfCjCV/versions/HwaLJe3v/appleskin-fabric-mc26.1-3.0.9.jar"
   },
-  "T42QJY4i": {
-    "sha512": "5da377423b2e48cf6729eab3f67eb82b21d591dee8ff060b2f9295c2743994ca3b49abe77c4b8d2480286c7e6e71f2f19afaf45e13d3794685b726cf2431fc19",
-    "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/T42QJY4i/voicechat-fabric-1.21.11-2.6.10.jar"
+  "R7MxYvuW": {
+    "sha512": "9231ad05667d4eef0348c700bf5160929e0b723d9e145fd97c7fcef9387ac2e6d524fb15d99f47f8f838f1d235324fd750cdcb6603b63aab6085d79fbeaab31b",
+    "url": "https://cdn.modrinth.com/data/gvQqBUqZ/versions/R7MxYvuW/lithium-fabric-0.24.2%2Bmc26.1.2.jar"
   },
-  "eRLwt73x": {
-    "sha512": "be600543e499b59286f9409f46497570adc51939ae63eaa12ac29e6778da27d8c7c6cd0b3340d8bcca1cc99ce61779b1a8f52b990f9e4e9a93aa9c6482905231",
-    "url": "https://cdn.modrinth.com/data/uXXizFIs/versions/eRLwt73x/ferritecore-8.0.3-fabric.jar"
+  "Yn66yzx3": {
+    "sha512": "d8d9fb387b26dc297e7123ff43c5fafd8377e16ee1f1569479a74d664d454d447e31bfabc214900d5b5e68147312b5552b0f6d7f52afc90852a5ee8d0d4bf613",
+    "url": "https://cdn.modrinth.com/data/2M01OLQq/versions/Yn66yzx3/shulkerboxtooltip-fabric-5.3.0%2B26.1.1.jar"
   },
-  "gB6TkYEJ": {
-    "sha512": "af4465797d80401021a6aefc8c547200e7c0f8cae134299bf3fafbc310fa81f055246b0614fc0e037538f4a844e55aad30abfa3c67460422853dfc426f086d00",
-    "url": "https://cdn.modrinth.com/data/P7dR8mSH/versions/gB6TkYEJ/fabric-api-0.140.2%2B1.21.11.jar"
+  "d5ddUdiB": {
+    "sha512": "d81fa97e11784c19d42f89c2f433831d007603dd7193cee45fa177e4a6a9c52b384b198586e04a0f7f63cd996fed713322578bde9a8db57e1188854ae5cbe584",
+    "url": "https://cdn.modrinth.com/data/uXXizFIs/versions/d5ddUdiB/ferritecore-9.0.0-fabric.jar"
   },
-  "pvcLnrm0": {
-    "sha512": "dfc990170b969f3213a9912d13c3fc0d067e2e88faf1a6c7a69bd1a463cd6144ac2dcaeb6a2a3150b595378c1f9449fb0740714ff7703c18c93f8ae3c9eceaa3",
-    "url": "https://cdn.modrinth.com/data/EsAfCjCV/versions/pvcLnrm0/appleskin-fabric-mc1.21.11-3.0.7.jar"
+  "gVPjsMto": {
+    "sha512": "1eb687a5210e7e15887e84a93195dd8ebcf45d85a2b657d27c711ad01ed8e9096f499fcb84d6564854989ed2c13b6a800665fbb382229977d1125e0d3eb5a836",
+    "url": "https://cdn.modrinth.com/data/9eGKb6K1/versions/gVPjsMto/voicechat-fabric-2.6.17%2B26.1.2.jar"
   }
 }

--- a/publicModules/nixos/modrinth-lock/server.nix
+++ b/publicModules/nixos/modrinth-lock/server.nix
@@ -37,16 +37,21 @@ let
             throw "Modrinth mod version '${versionId}' not found in `${opts.locks.modrinth}` (try re-generating your lockfile). Defined in:${locations}"
           );
       in
-      pkgs.fetchurl {
-        inherit (lock) url sha512;
-        passthru = {
-          modrinth = true;
-          inherit versionId;
+      {
+        modrinth = true;
+        inherit versionId;
+        outPath = pkgs.fetchurl {
+          inherit (lock) url sha512;
         };
       };
   };
 
-  modType = lib.types.coercedTo taggedMod coerceTagged lib.types.path;
+  # lib.types.path is too strict; meaning we cannot evaluate unlocked versions and later run the locking script.
+  lazyPath = lib.types.raw // {
+    inherit (lib.types.path) description descriptionClass;
+  };
+
+  modType = lib.types.coercedTo taggedMod coerceTagged lazyPath;
 in
 assert
   (builtins.attrNames taggedMod.nestedTypes)


### PR DESCRIPTION
- **chore(flake): update nix-minecraft input**
- **fix(modrinth-lock): make `mods` definitions lazier**
- **chore(minecraft): update quad world to 26.1.2**
