### PR TITLE
feat(emacs): install Doom Emacs on activation

### DIFF
--- a/modules/home-manager/emacs.nix
+++ b/modules/home-manager/emacs.nix
@@ -27,35 +27,6 @@ in
           })
         ];
       });
-
-      extraPackages =
-        epkgs: with epkgs; [
-          catppuccin-theme
-          # 2025-12-20: tree-sitter-razor is marked as broken
-          # treesit-grammars.with-all-grammars
-        ];
-
-      extraConfig = # lisp
-        ''
-          ;;; For performance, increase GC threshold during init
-          (setq gc-cons-threshold 100000000)
-          (setq read-process-output-max (* 1024 1024)) ;; 1mb
-
-          ;;; Restore normal GC after init
-          (add-hook 'after-init-hook #'(lambda () (setq gc-cons-threshold 800000)))
-
-          ;;; Disable menu-bar, tool-bar, and scroll-bar.
-          (if (fboundp 'menu-bar-mode)
-              (menu-bar-mode -1))
-          (if (fboundp 'tool-bar-mode)
-              (tool-bar-mode -1))
-          (if (fboundp 'scroll-bar-mode)
-              (scroll-bar-mode -1))
-
-          ;;; Colorscheme
-          (setq catppuccin-flavor 'mocha)
-          (load-theme 'catppuccin :no-confirm)
-        '';
     };
 
     services.emacs = {
@@ -67,5 +38,55 @@ in
       socketActivation.enable = true;
       # extraOptions = [ ];
     };
+
+    home.packages = with pkgs; [
+      # Doom Emacs dependencies
+      # https://github.com/doomemacs/doomemacs/blob/master/docs/getting_started.org#nixos
+      git
+      ripgrep
+      coreutils
+      fd
+      clang
+    ];
+
+    home.activation.setupDoomEmacs =
+      lib.hm.dag.entryAfter [ "writeBoundary" "linkGeneration" "cleanUp" ]
+        /* bash */ ''
+          setupDoomEmacs() {
+            log() {
+              echo "setupDoomEmacs: $*" >&2
+            }
+            local ${lib.toShellVar "emacs" "${config.xdg.configHome}/emacs"}
+            local ${lib.toShellVar "config" "${config.xdg.configHome}/doom"}
+
+            if [ -d "$emacs" ]; then
+              # Assert Doom Emacs is installed
+              [ -f "$emacs"/bin/doom ] || {
+                log "Skipping Doom Emacs installation, another Emacs config exists at $emacs"
+                return
+              }
+            else
+              # Install Doom Emacs
+              ${lib.getExe pkgs.gitMinimal} clone --depth 1 https://github.com/doomemacs/doomemacs "$emacs"
+              yes | "$emacs"/bin/doom install
+            fi
+
+
+            # TODO: symlink mutable config to ~/.config/doom
+            # Or clone a config repo, managed separately from this repo?
+            if [ ! -d "$config" ]; then
+              log "No Doom Emacs config found"
+            fi
+
+            # Sync
+            "$emacs"/bin/doom sync
+
+          }
+          setupDoomEmacs
+        '';
+
+    home.sessionPath = [
+      "${config.xdg.configHome}/emacs/bin"
+    ];
   };
 }

--- a/modules/home-manager/intellij.nix
+++ b/modules/home-manager/intellij.nix
@@ -190,47 +190,50 @@ in
 
     home.activation.installIdeavimrc = lib.mkIf (cfg.vimrc.enable && cfg.vimrc.mutable) (
       lib.hm.dag.entryAfter [ "writeBoundary" "linkGeneration" "cleanUp" ] /* bash */ ''
-        log() {
-          echo "installIdeavimrc: $*" >&2
-        }
+        installIdeavimrc() {
+          log() {
+            echo "installIdeavimrc: $*" >&2
+          }
 
-        ${lib.toShellVar "source" "${cfg.vimrc.source}"}
-        target="$HOME/.ideavimrc"
+          ${lib.toShellVar "source" "${cfg.vimrc.source}"}
+          target="$HOME/.ideavimrc"
 
-        if [ -e "$target" ]; then
-          if cmp -s "$target" "$source"; then
-            # Already up to date, nothing to do
-            log "existing $target has not changed"
-            exit 0
-          fi
+          if [ -e "$target" ]; then
+            if cmp -s "$target" "$source"; then
+              # Already up to date, nothing to do
+              log "existing $target has not changed"
+              return
+            fi
 
-          # Find the latest backup
-          latest_backup=
-          for backup in "$target".[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*; do
-            [ -e "$backup" ] || continue
-            latest_backup="$backup"
-          done
-
-          # Create a new backup
-          if [ -n "$latest_backup" ] && cmp -s "$target" "$latest_backup"; then
-            log "existing $target already has a valid backup: $latest_backup"
-            log "view changes using: diff '$latest_backup' '$target'"
-          else
-            n=1
-            date="$(date +%F)"
-            while :; do
-              backup="$target.$date.$n"
-              [ -e "$backup" ] || break
-              n=$((n + 1))
+            # Find the latest backup
+            latest_backup=
+            for backup in "$target".[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].*; do
+              [ -e "$backup" ] || continue
+              latest_backup="$backup"
             done
 
-            log "backing up $target → $backup"
-            log "view changes using: diff '$backup' '$target'"
-            mv "$target" "$backup"
-          fi
-        fi
+            # Create a new backup
+            if [ -n "$latest_backup" ] && cmp -s "$target" "$latest_backup"; then
+              log "existing $target already has a valid backup: $latest_backup"
+              log "view changes using: diff '$latest_backup' '$target'"
+            else
+              n=1
+              date="$(date +%F)"
+              while :; do
+                backup="$target.$date.$n"
+                [ -e "$backup" ] || break
+                n=$((n + 1))
+              done
 
-        install -TDm644 "$source" "$target"
+              log "backing up $target → $backup"
+              log "view changes using: diff '$backup' '$target'"
+              mv "$target" "$backup"
+            fi
+          fi
+
+          install -TDm644 "$source" "$target"
+        }
+        installIdeavimrc
       ''
     );
   };


### PR DESCRIPTION
On activation, install doom emacs into `~/.config/emacs` if not already present and run `doom sync`.

Future work: also install a doom emacs _config_ into `~/.config/doom`.