### PR TITLE
chore(flake): update inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1780733803,
-        "narHash": "sha256-QBJPq12P1DAXFGezoEJaSO/xPUrPlnaI3ddSaMG2JpM=",
+        "lastModified": 1780804967,
+        "narHash": "sha256-Z2nOP600ATQLLHHemhHtYDjWyAqgLrVsozznIkvnkYY=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "c80b0aa94392c5f3612ac797108f6d952752036d",
+        "rev": "f15cdd20d0845728919ad067ff43bdd334b4b344",
         "type": "gitlab"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
-        "owner": "nixos",
+        "lastModified": 1780795668,
+        "narHash": "sha256-RAPmF/rximnsPEVkHxGuLAMekHsQWsFou+Dmqw5PjnQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "afdf13dce322e2aec0a57490a45df202367ec2e2",
         "type": "github"
       },
       "original": {
@@ -278,11 +278,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780646548,
-        "narHash": "sha256-Ckyl/l1XBmEwnaHcHD8PvBZk1uph0NqwbJ//CAvB7iE=",
+        "lastModified": 1780849525,
+        "narHash": "sha256-yjtMubbmPi4Y4pgDSdmytqUutGJ+LJLcPgXGNNdXiUs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "816a15282e58678dde831477964987d0262d4293",
+        "rev": "98acb923e5882a6a6a2b660d99e8c5124e08b838",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`nixos-unstable` has been blocked for a while, so attempting a manual bump to `nixos-unstable-small`.

This includes https://github.com/NixOS/nixpkgs/pull/526805, which will unblock #151 

``````
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/c80b0aa94392c5f3612ac797108f6d952752036d?dir=pkgs/firefox-addons&narHash=sha256-QBJPq12P1DAXFGezoEJaSO/xPUrPlnaI3ddSaMG2JpM%3D' (2026-06-06)
  → 'gitlab:rycee/nur-expressions/f15cdd20d0845728919ad067ff43bdd334b4b344?dir=pkgs/firefox-addons&narHash=sha256-Z2nOP600ATQLLHHemhHtYDjWyAqgLrVsozznIkvnkYY%3D' (2026-06-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/331800de5053fcebacf6813adb5db9c9dca22a0c?narHash=sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw%3D' (2026-05-31)
  → 'github:NixOS/nixpkgs/afdf13dce322e2aec0a57490a45df202367ec2e2?narHash=sha256-RAPmF/rximnsPEVkHxGuLAMekHsQWsFou%2BDmqw5PjnQ%3D' (2026-06-07)
• Updated input 'nixvim':
    'github:nix-community/nixvim/816a15282e58678dde831477964987d0262d4293?narHash=sha256-Ckyl/l1XBmEwnaHcHD8PvBZk1uph0NqwbJ//CAvB7iE%3D' (2026-06-05)
  → 'github:nix-community/nixvim/98acb923e5882a6a6a2b660d99e8c5124e08b838?narHash=sha256-yjtMubbmPi4Y4pgDSdmytqUutGJ%2BLJLcPgXGNNdXiUs%3D' (2026-06-07)
• Updated input 'systems':
    'path:systems.nix'
  → 'path:systems.nix'
``````
